### PR TITLE
Fix: 상품페이지 => 장바구니페이지 데이터 렌더링 코드 수정

### DIFF
--- a/db.json
+++ b/db.json
@@ -65,5 +65,82 @@
       "price": 23000,
       "image": "/img/waffle.jpg"
     }
+  ],
+  "cart": [
+    {
+      "product": {
+        "id": 1,
+        "brand": "Illy",
+        "name": "일리 커피",
+        "price": 19000,
+        "image": "/img/illy-capsule.jpg"
+      },
+      "quantity": 2,
+      "totalAmount": 38000,
+      "id": 1
+    },
+    {
+      "product": {
+        "id": 2,
+        "brand": "Nescafe",
+        "name": "네스카페 캡슐 커피",
+        "price": 18000,
+        "image": "/img/nescafe-capsule.jpg"
+      },
+      "quantity": 2,
+      "totalAmount": 36000,
+      "id": 2
+    },
+    {
+      "product": {
+        "id": 2,
+        "brand": "Nescafe",
+        "name": "네스카페 캡슐 커피",
+        "price": 18000,
+        "image": "/img/nescafe-capsule.jpg"
+      },
+      "quantity": 1,
+      "totalAmount": 18000,
+      "id": 3
+    }
+  ],
+  "purchases": [
+    {
+      "productId": "1",
+      "quantity": 1,
+      "totalAmount": 19000,
+      "id": 1
+    },
+    {
+      "productId": "1",
+      "quantity": 1,
+      "totalAmount": 19000,
+      "id": 2
+    },
+    {
+      "cartItems": [
+        {
+          "productId": 1,
+          "quantity": 1,
+          "totalAmount": 19000
+        },
+        {
+          "productId": 2,
+          "quantity": 1,
+          "totalAmount": 18000
+        },
+        {
+          "productId": 2,
+          "quantity": 1,
+          "totalAmount": 18000
+        },
+        {
+          "productId": 1,
+          "quantity": 1,
+          "totalAmount": 19000
+        }
+      ],
+      "id": 3
+    }
   ]
 }

--- a/src/App.css
+++ b/src/App.css
@@ -36,6 +36,7 @@ h2 {
 }
 
 button {
+  cursor: pointer;
   border-style: none;
   background-color: transparent;
 }

--- a/src/components/CartItem.jsx
+++ b/src/components/CartItem.jsx
@@ -1,74 +1,108 @@
 import axios from "axios";
 import { useState, useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { add, remove } from "../img/index";
 
 function CartItem() {
-  const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
-
-  const productId = searchParams.get("productId");
-  const initialQuantity = parseInt(searchParams.get("quantity"));
-  const initialTotalAmount = parseInt(searchParams.get("totalAmount"));
-
-  const [product, setProduct] = useState({});
-  const [quantity, setQuantity] = useState(initialQuantity);
-  const [totalAmount, setTotalAmount] = useState(initialTotalAmount);
+  const navigate = useNavigate();
+  const [products, setProducts] = useState([]);
+  const [quantities, setQuantities] = useState([]);
+  const [totalAmounts, setTotalAmounts] = useState([]);
+  console.log(products);
+  console.log(quantities);
+  console.log(totalAmounts);
 
   useEffect(() => {
-    const fetchProductData = async () => {
+    const fetchCartData = async () => {
       try {
-        const res = await axios.get(
-          `http://localhost:4001/products/${productId}`
-        );
-        setProduct(res.data);
+        const res = await axios.get(`http://localhost:4001/cart`);
+        setProducts(res.data);
+
+        // 초기값으로 각 상품의 수량과 총액을 가져온 데이터로 설정
+        const initialQuantities = {};
+        const initialTotalAmounts = {};
+        res.data.forEach((product) => {
+          initialQuantities[product.id] = product.quantity;
+          initialTotalAmounts[product.id] = product.totalAmount;
+        });
+        setQuantities(initialQuantities);
+        setTotalAmounts(initialTotalAmounts);
       } catch (err) {
-        console.error("Error fetching product:", err);
+        console.error("Error fetching cart data:", err);
       }
     };
 
-    fetchProductData();
-  }, [productId]);
+    fetchCartData();
+  }, []);
 
-  const handlePlusQuantity = () => {
-    setQuantity(quantity + 1);
-    setTotalAmount((quantity + 1) * product.price);
+  const handlePlusQuantity = (id) => {
+    setQuantities((prevQuantities) => ({
+      ...prevQuantities,
+      [id]: prevQuantities[id] + 1,
+    }));
+
+    setTotalAmounts((prevTotalAmounts) => ({
+      ...prevTotalAmounts,
+      [id]:
+        (quantities[id] + 1) *
+        products.find((product) => product.id === id).product.price,
+    }));
   };
 
-  const handleMinusQuantity = () => {
-    if (quantity > 1) {
-      setQuantity(quantity - 1);
-      setTotalAmount((quantity - 1) * product.price);
+  const handleMinusQuantity = (id) => {
+    if (quantities[id] > 1) {
+      setQuantities((prevQuantities) => ({
+        ...prevQuantities,
+        [id]: prevQuantities[id] - 1,
+      }));
+
+      setTotalAmounts((prevTotalAmounts) => ({
+        ...prevTotalAmounts,
+        [id]:
+          (quantities[id] - 1) *
+          products.find((product) => product.id === id).product.price,
+      }));
+    }
+  };
+
+  const handlePurchase = async () => {
+    try {
+      await axios.post(`http://localhost:4001/purchases`);
+      navigate("/my/purchase-history");
+    } catch (error) {
+      console.error("구매 정보를 서버에 전송하는 중 오류 발생:", error);
     }
   };
 
   return (
     <>
       <div className="my-nav-title">장바구니 내역</div>
-      {product.length === 0 ? (
+      {products.length === 0 ? (
         <p className="no-data">장바구니에 담긴 상품이 없습니다.</p>
       ) : (
         <div className="my-cart-container">
-          <div key={product.id} className="cart-item">
-            <img src={product.image} className="item-img" />
-            <div className="quantity-area">
-              <div className="quantity-controls">
-                <button onClick={handleMinusQuantity}>
-                  <img src={remove} width={18} height={18} />
-                </button>
-                <span className="item-total">{quantity}</span>
-                <button onClick={handlePlusQuantity}>
-                  <img src={add} width={18} height={18} />
-                </button>
+          {products.map((product) => (
+            <div key={product.id} className="cart-item">
+              <img src={product.product.image} className="item-img" />
+              <div className="quantity-area">
+                <div className="quantity-controls">
+                  <button onClick={() => handleMinusQuantity(product.id)}>
+                    <img src={remove} width={18} height={18} />
+                  </button>
+                  <span className="item-total">{quantities[product.id]}</span>
+                  <button onClick={() => handlePlusQuantity(product.id)}>
+                    <img src={add} width={18} height={18} />
+                  </button>
+                </div>
+                <span>{totalAmounts[product.id]} 원</span>
               </div>
-              <span>{totalAmount} 원</span>
+              <button className="item-delete">삭제</button>
             </div>
-            <button className="item-delete">삭제</button>
-          </div>
+          ))}
         </div>
       )}
       <div className="order-button">
-        <button>전체 구매하기</button>
+        <button onClick={handlePurchase}>전체 구매하기</button>
       </div>
     </>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -30,9 +30,9 @@ function Header() {
         OZIK
       </Link>
       <div className="icon-container">
-        <span onClick={handleLogout} className="login-icon">
+        <button onClick={handleLogout} className="login-icon">
           {user ? "로그아웃" : ""}
-        </span>
+        </button>
         <Link to="/search" className="search-icon">
           <img src={search} alt="Search" />
         </Link>

--- a/src/components/PurchaseList.jsx
+++ b/src/components/PurchaseList.jsx
@@ -1,11 +1,48 @@
+import axios from "axios";
+import { useState, useEffect } from "react";
+
 function PurchaseList() {
+  const [products, setProducts] = useState({});
+  console.log(products);
+
+  useEffect(() => {
+    const fetchProductData = async () => {
+      try {
+        const res = await axios.get(`http://localhost:4001/purchases`);
+        setProducts(res.data);
+      } catch (err) {
+        console.err("Error fetching product:", err);
+      }
+    };
+
+    fetchProductData();
+  }, []);
+
   return (
     <>
       <p className="my-nav-title">구매 내역</p>
-      <p className="no-data">구매하신 상품이 없습니다.</p>
-      <div className="my-purchased-container">
-        <div className="my-purchsed-item"></div>
-      </div>
+      {products.length === 0 ? (
+        <p className="no-data">구매하신 상품이 없습니다.</p>
+      ) : (
+        // <div className="my-purchased-container">
+        //   <div key={products.id} className="my-purchsed-item"></div>
+        // </div>
+        <div className="my-cart-container">
+          {products.length > 0 &&
+            products.map((product) => {
+              <div key={product.id} className="cart-item">
+                <img src={product.image} className="item-img" />
+                <div className="quantity-area">
+                  <div className="quantity-controls">
+                    <span className="item-total">{product.quantity}</span>
+                  </div>
+                  <span>{product.totalAmount} 원</span>
+                </div>
+                <button className="item-delete">삭제</button>
+              </div>;
+            })}
+        </div>
+      )}
     </>
   );
 }

--- a/src/pages/Product.jsx
+++ b/src/pages/Product.jsx
@@ -1,11 +1,12 @@
 import axios from "axios";
 import { useState, useEffect } from "react";
-import { Link, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import "../styles/product.scss";
 import { add, remove } from "../img";
 
 function ProductPage() {
   const { productId } = useParams();
+  const navigate = useNavigate();
   const [product, setProduct] = useState("");
   const [loading, setLoading] = useState(false);
   const [isPurchasing, setIsPurchasing] = useState(false);
@@ -40,9 +41,22 @@ function ProductPage() {
     setIsAdding(false);
   };
 
-  const handleAddClick = () => {
-    setIsAdding(!isAdding);
-    setIsPurchasing(false);
+  const handleCartClick = async () => {
+    try {
+      const res = await axios.post("http://localhost:4001/cart", {
+        product,
+        quantity,
+        totalAmount,
+      });
+      if (res.status === 200) {
+        alert("상품이 장바구니에 추가되었습니다.");
+      }
+      navigate("/my/cart");
+      setIsAdding(!isAdding);
+      setIsPurchasing(false);
+    } catch (err) {
+      console.error("상품을 추가하는 중 오류 발생:", err);
+    }
   };
 
   const handlePlusQuantity = () => {
@@ -99,14 +113,10 @@ function ProductPage() {
             </div>
             <div className="button-area">
               <button
-                onClick={handleAddClick}
+                onClick={handleCartClick}
                 className={`button ${isAdding ? "clicked" : ""}`}
               >
-                <Link
-                  to={`/my/cart?productId=${productId}&quantity=${quantity}&totalAmount=${totalAmount}`}
-                >
-                  고민해볼래요
-                </Link>
+                고민해볼래요
               </button>
               <button
                 onClick={handlePurchaseClick}


### PR DESCRIPTION
😃 Key Changes

- 상품페이지에서 post 요청을 보내는 부분 놓쳐서 수정 진행
   => 기존에 상품페이지에서 장바구니페이지로 이동할 때 해당 데이터를 post 하지 않고 이벤트 핸들링으로 URL 동적라우팅을 사용하는 코드 작성했어서 구현하려던 장바구니페이지가 제대로 작동할 일이 없었음...
- 장바구니페이지에서도 다시 get 요청으로 장바구니에 담긴 데이터를 불러서 렌더링하도록 수정
- 이 때도 상품의 수량을 올리거나 내리면 그에 따른 가격이 변동되도록 코드 추가하였음
   =>  이 부분은 index를 기준으로 삼을까하다가 상품이 삭제되었을 때 index가 바뀔 경우를 대비해서 product.id를 기준으로 하였음
